### PR TITLE
add 0-trinitarianism/quest-5 to the index

### DIFF
--- a/docs/source/0-trinitarianism/index.rst
+++ b/docs/source/0-trinitarianism/index.rst
@@ -16,3 +16,4 @@ Trinitarianism
    quest-3-side
    quest-4
    quest-4-side
+   quest-5


### PR DESCRIPTION
I get that it's a work in progress but it already seems complete enough to be useful (especially considering that it's referenced in 1-fundamental-group/quest-3).