### PR TITLE
fixed typo: singleton space should be ⊤, not ⊥

### DIFF
--- a/docs/source/0-trinitarianism/quest-4-side.rst
+++ b/docs/source/0-trinitarianism/quest-4-side.rst
@@ -37,7 +37,7 @@ we can refine, and ``agda`` will assume such an ``i`` for us.
 
    funExt : {B : A → Type} {f g : (a : A) → B a} →
      ((a : A) → f a ≡ g a) → f ≡ g
-   funExt {B = B} {f = f} {g = g} h = λ i a → {!!}
+   funExt h = λ i a → {!!}
 
 Checking the goal you should see something like the following
 (we have extracted the important parts):
@@ -49,9 +49,9 @@ Checking the goal you should see something like the following
   a : A
   i : I
   h : (a₁ : A) → f a₁ ≡ g a₁
-  g : (a₁ : A) → B a₁
-  f : (a₁ : A) → B a₁
-  B : A → Type
+  g : (a₁ : A) → B a₁   (not in scope)
+  f : (a₁ : A) → B a₁   (not in scope)
+  B : A → Type   (not in scope)
   A : Type   (not in scope)
   ———— Constraints ————————————————————————
   ?0 (i = i1) = g a : B a
@@ -97,7 +97,7 @@ gives us a path from ``f a`` to ``g a`` in ``B a``.
 
   funExt : {B : A → Type} {f g : (a : A) → B a} →
     ((a : A) → f a ≡ g a) → f ≡ g
-  funExt B f g h = λ i a → h a i
+  funExt h = λ i a → h a i
 
 .. raw:: html
 

--- a/docs/source/0-trinitarianism/quest-4-side.rst
+++ b/docs/source/0-trinitarianism/quest-4-side.rst
@@ -37,7 +37,7 @@ we can refine, and ``agda`` will assume such an ``i`` for us.
 
    funExt : {B : A → Type} {f g : (a : A) → B a} →
      ((a : A) → f a ≡ g a) → f ≡ g
-   funExt B f g h = λ i a → {!!}
+   funExt {B = B} {f = f} {g = g} h = λ i a → {!!}
 
 Checking the goal you should see something like the following
 (we have extracted the important parts):

--- a/docs/source/1-fundamental-group/quest-2.rst
+++ b/docs/source/1-fundamental-group/quest-2.rst
@@ -71,7 +71,7 @@ is trivial, in the sense that it just consists of a point (up to paths) :
 Intuitively this is because the only loop (up to a path) in ``ℤ`` from
 ``0`` to itself is ``refl``,
 so ``loopSpace ℤ 0`` is contractible -
-it looks just like the singleton space ``⊥``.
+it looks just like the singleton space ``⊤``.
 This is more general : *any two paths in* ``ℤ`` *are homotopic*,
 which we formalise in the definition ``isSet``.
 


### PR DESCRIPTION
The singleton space is ⊤, not ⊥, consistent with the snippet above that says there's a path loopSpace ℤ 0 ≡ ⊤.